### PR TITLE
Add SQLite database support for managing downloaded episodes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+downloads.db
 
 # Flask stuff:
 instance/

--- a/README.md
+++ b/README.md
@@ -1,69 +1,83 @@
 # RSS Podcast Downloader
 
-This Python script downloads audio files and accompanying text information from specified RSS feeds. It was quickly
-developed to download the complete archive of the [The Last Podcast on the Left](https://www.lastpodcastontheleft.com/)
-collection from their Patreon RSS feed...It has not been tested extensively, but it _should_ work for most RSS feeds.
+A powerful and flexible Python script to download, manage, and archive podcast episodes from any RSS feed.
 
 ## Description
 
-`RSS Podcast Downloader` is a tool for downloading podcasts from any given RSS feed. It not only fetches audio files but also allows the option to save additional episode details in a text file, ensuring a comprehensive podcast experience.
+`RSS Podcast Downloader` is a robust tool for downloading podcasts from any given RSS feed. It is designed to be a "set it and forget it" solution, with features that support resuming downloads and tracking your library across multiple podcast feeds.
 
-It will only download podcast entries that are published with the link type, `audio/mpeg`. Furthermore, at this time
+The script creates clean, portable filenames and can enrich your media library by automatically writing episode metadata (like title, album, and artist) to the downloaded MP3 files.
 
-
-The filenames have an opinionated convention and are based on the following format:
-
-```text
-YYYY-MM-DD_lowercase_underbar_delimited_title.xyz
-```
-
-The prepended date is the publication date of the podcast episode.
+A local SQLite database (`downloads.db`) is created in the script's directory to keep track of all downloaded episodes, preventing duplicates and allowing you to manage podcasts from multiple feeds seamlessly.
 
 ## Features
 
-- **Download Audio Files**: Automatically download audio files from the RSS feed.
-- **Save Episode Details**: Optionally save additional episode details in a text file.
-- **Filesystem-Friendly Filenames**: Sanitizes titles to create filenames compatible with most filesystems.
+- **Download Resuming**: Automatically tracks downloaded episodes in a local database and skips them on subsequent runs.
+- **Multi-Feed Support**: Tracks episodes from multiple RSS feeds independently.
+- **MP3 Tagging**: Automatically writes ID3 metadata (Title, Album, Artist, Date, Genre, etc.) to downloaded MP3 files.
+- **Download Limiting**: Use the `--num-episodes` flag to check only the latest `N` episodes for anything new.
+- **Smart Filename Sanitization**: Converts episode titles into clean, ASCII-only, filesystem-friendly filenames.
+- **Save Episode Details**: Optionally save episode summaries in a separate text file.
 - **Command-Line Interface**: Simple CLI for specifying the RSS feed URL and save directory.
-- **Error Handling**: Provides clear error messages for common issues like download failures or RSS feed fetching errors.
+- **Error Handling**: Provides clear error messages and retry logic for downloads.
 
-## Usage
+## Filename Convention
 
-To use this script, you need to provide the RSS feed URL and the directory where the files will be saved. The `--save_text` flag can be used to save additional episode details in a text file.
+The script generates filenames with a clean, consistent, and sortable convention:
 
-```bash
-python rss-podcast-downloader.py <RSS_FEED_URL> <SAVE_DIRECTORY> [--save_text]
+```text
+YYYY-MM-DD_lowercase_and_ascii_title.mp3
 ```
+The prepended date is the publication date of the podcast episode.
 
 ## Requirements
 
-- Python 3.x 
-- Required Python packages (see requirements.txt)
-
-To install the required packages, run:
-
-```bash
-pip install -r requirements.txt
-```
+- Python 3.x
+- Required Python packages (see `requirements.txt`)
 
 ## Installation
 
-```commandline
-git clone git@github.com:johnsosoka/rss-podcast-downloader.git
-cd rss-podcast-downloader
-pip install -r requirements.txt
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/johnsosoka/rss-podcast-downloader.git
+   cd rss-podcast-downloader
+   ```
+2. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+The script requires the RSS feed URL and a directory to save the downloaded files.
+
+```bash
+python rss-podcast-downloader.py <RSS_FEED_URL> <SAVE_DIRECTORY> [OPTIONS]
 ```
+
+### Arguments
+
+- `<RSS_FEED_URL>`: The URL of the podcast's RSS feed. (Required)
+- `<SAVE_DIRECTORY>`: The local directory where podcast files will be saved. (Required)
+
+### Options
+
+- `--num-episodes <N>`: Check only the `<N>` most recent episodes in the feed for new downloads. This is useful for quickly syncing the latest episodes without checking the entire feed history.
+- `--save_text`: Flag to save additional episode details (like the summary) in a separate `.txt` file alongside the audio file.
 
 ## Examples
 
-**Save Audio Files + Text Files with Episode Details**
-
+**Initial Run: Download all episodes for a podcast**
 ```bash
-python rss-podcast-downloader.py "http://example.com/rss" "./podcasts" --save_text
+python rss-podcast-downloader.py "http://example.com/podcast.rss" "./podcasts/MyShow"
 ```
 
-**Save Audio Files Only**
-
+**Daily Sync: Check for the 5 latest episodes and download any that are missing**
 ```bash
-python rss-podcast-downloader.py "http://example.com/rss" "./podcasts"
+python rss-podcast-downloader.py "http://example.com/podcast.rss" "./podcasts/MyShow" --num-episodes 5
+```
+
+**Sync and Save Text Files**
+```bash
+python rss-podcast-downloader.py "http://another-feed.com/rss" "./podcasts/AnotherShow" --save_text
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ idna==3.7
 requests==2.32.0
 sgmllib3k==1.0.0
 urllib3==2.2.1
+mutagen

--- a/rss-podcast-downloader.py
+++ b/rss-podcast-downloader.py
@@ -6,7 +6,11 @@ import os
 import argparse
 import time
 import logging
+import sqlite3
+import unicodedata
 from urllib.parse import urlparse, unquote
+from mutagen.mp3 import MP3
+from mutagen.id3 import ID3, TALB, TPE1, TIT2, TDRC, COMM, TPE2, TCON
 
 """
 RSS Downloader Script
@@ -44,25 +48,114 @@ Author: John Sosoka
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+def setup_database():
+    """Initializes the SQLite database in the script's directory."""
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    db_path = os.path.join(script_dir, 'downloads.db')
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Simple migration: check if episodes table has feed_id. If not, archive it.
+    try:
+        cursor.execute("PRAGMA table_info(episodes)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if 'feed_id' not in columns:
+            logging.warning("Old database schema detected. Archiving old 'episodes' table and creating new schema. Download history will be reset.")
+            cursor.execute("ALTER TABLE episodes RENAME TO episodes_old_pre_multi_feed")
+    except sqlite3.OperationalError:
+        # This happens if the episodes table doesn't exist at all, which is fine.
+        pass
+
+    # Create tables with the new schema
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS feeds (
+            feed_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            feed_url TEXT UNIQUE NOT NULL,
+            feed_title TEXT
+        )
+    ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS episodes (
+            episode_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            feed_id INTEGER NOT NULL,
+            guid TEXT NOT NULL,
+            title TEXT,
+            published TEXT,
+            filepath TEXT,
+            downloaded_at TEXT,
+            FOREIGN KEY (feed_id) REFERENCES feeds (feed_id),
+            UNIQUE (feed_id, guid)
+        )
+    ''')
+    conn.commit()
+    logging.info(f"Database setup complete at {db_path}")
+    return conn
+
+def get_or_create_feed(conn, feed_url, feed_title):
+    """Gets the feed_id for a given feed_url, creating it if it doesn't exist."""
+    cursor = conn.cursor()
+    cursor.execute("SELECT feed_id FROM feeds WHERE feed_url = ?", (feed_url,))
+    result = cursor.fetchone()
+    if result:
+        return result[0]
+    else:
+        cursor.execute("INSERT INTO feeds (feed_url, feed_title) VALUES (?, ?)", (feed_url, feed_title))
+        conn.commit()
+        logging.info(f"Added new feed to database: {feed_title}")
+        return cursor.lastrowid
+
+
 def sanitize_title(title, date_str=None):
     """
     Convert a podcast episode title to a filesystem-friendly filename,
     prepending the date in the format (YYYY-MM-DD) if provided.
     """
-    # Remove characters that are not allowed in filenames
-    sanitized_title = re.sub(r'[\\/*?:"<>|]', '', title)
+    # Normalize unicode characters to their ASCII equivalent
+    try:
+        normalized_title = unicodedata.normalize('NFKD', title)
+        ascii_title = normalized_title.encode('ascii', 'ignore').decode('ascii')
+    except Exception as e:
+        logging.warning(f"Could not normalize title '{title}'. Using it as is. Error: {e}")
+        ascii_title = title
 
-    # Replace spaces with underscores for readability
-    sanitized_title = sanitized_title.replace(' ', '_').lower()
+    # Replace dashes and spaces
+    sanitized_title = ascii_title.replace(' ', '_')
+    
+    # Remove any character that is not a letter, a number, a dot, an underscore or a dash.
+    sanitized_title = re.sub(r'[^a-zA-Z0-9._-]', '', sanitized_title)
+
+    # Collapse multiple underscores or dashes
+    sanitized_title = re.sub(r'__+', '_', sanitized_title)
+    sanitized_title = re.sub(r'--+', '-', sanitized_title)
+    
+    # Remove leading/trailing underscores or dashes
+    sanitized_title = sanitized_title.strip('_-')
+
+    # Convert to lowercase
+    sanitized_title = sanitized_title.lower()
 
     # Prepend date in the specified format if provided
     if date_str:
-        try:
-            date = datetime.strptime(date_str, '%a, %d %b %Y %H:%M:%S %Z')
+        date = None
+        # List of common date formats to try for RSS feeds
+        formats_to_try = [
+            '%a, %d %b %Y %H:%M:%S %Z',  # With timezone name e.g. GMT
+            '%a, %d %b %Y %H:%M:%S %z',  # With timezone offset e.g. +0000
+            '%a, %d %b %Y %H:%M:%S',    # Without timezone
+        ]
+
+        for format_str in formats_to_try:
+            try:
+                date = datetime.strptime(date_str, format_str)
+                break  # Successfully parsed
+            except ValueError:
+                continue  # Try the next format
+
+        if date:
             date_formatted = date.strftime('%Y-%m-%d')
             sanitized_title = f'{date_formatted}_{sanitized_title}'
-        except ValueError as e:
-            logging.error(f"Error parsing date: {e}")
+        else:
+            logging.warning(f"Could not parse date: '{date_str}'. Filename will not have a date prefix.")
 
     return sanitized_title
 
@@ -111,50 +204,154 @@ def save_text_file(entry, filename):
         file.write(f"Published Date: {entry.get('published', 'N/A')}\n")
         file.write(f"Content: {entry.get('summary', 'N/A')}\n")
 
-def parse_and_download(content, save_dir, save_text):
+def set_mp3_tags(filename, entry, feed):
+    """Set MP3 tags using metadata from the RSS feed."""
+    try:
+        audio = MP3(filename, ID3=ID3)
+    except Exception as e:
+        logging.error(f"Could not open file for tagging: {filename} - {e}")
+        return
+
+    # Add ID3 tag if it doesn't exist
+    if audio.tags is None:
+        audio.add_tags()
+
+    # Album (Podcast Title)
+    if 'title' in feed.feed:
+        audio.tags.add(TALB(encoding=3, text=feed.feed.title))
+
+    # Artist (Podcast Author)
+    artist = entry.get('author') or feed.feed.get('author')
+    if artist:
+        audio.tags.add(TPE1(encoding=3, text=artist))
+        audio.tags.add(TPE2(encoding=3, text=artist))
+
+    # Title (Episode Title)
+    if 'title' in entry:
+        audio.tags.add(TIT2(encoding=3, text=entry.title))
+    
+    # Date (Published Date)
+    if entry.get('published_parsed'):
+        pub_date = datetime(*entry.published_parsed[:6])
+        audio.tags.add(TDRC(encoding=3, text=pub_date.strftime('%Y-%m-%dT%H:%M:%S')))
+    
+    # Comment (Summary)
+    summary = entry.get('summary')
+    if summary:
+        audio.tags.add(COMM(encoding=3, lang='eng', text=summary))
+        
+    # Genre from RSS category
+    if hasattr(feed.feed, 'tags') and feed.feed.tags:
+        genre = feed.feed.tags[0].term
+        audio.tags.add(TCON(encoding=3, text=genre))
+
+    audio.save()
+    logging.info(f"Successfully set MP3 tags for: {filename}")
+
+
+def parse_and_download(content, save_dir, save_text, num_episodes=None, conn=None, feed_id=None, feed=None):
     """Parse the RSS feed and download files."""
-    feed = feedparser.parse(content)
+    if not conn or not feed_id or not feed:
+        logging.error("Database connection, feed_id, or feed object not provided.")
+        return
 
-    # Count total audio files
-    total_audio_files = sum(1 for entry in feed.entries if any(link.type == 'audio/mpeg' for link in entry.get('links', [])))
-    logging.info(f"Total audio files to download: {total_audio_files}")
+    cursor = conn.cursor()
 
-    audio_file_counter = 0
+    all_episodes = [
+        (entry, link)
+        for entry in feed.entries
+        for link in entry.get('links', [])
+        if link.type == 'audio/mpeg'
+    ]
+
+    # If --num-episodes is used, only consider the latest N episodes from the feed
+    episodes_to_consider = all_episodes
+    if num_episodes is not None:
+        logging.info(f"--num-episodes set to {num_episodes}. Considering only the latest {num_episodes} episodes from the feed.")
+        episodes_to_consider = all_episodes[:num_episodes]
+
+    # Filter out episodes that have already been downloaded from the considered list
+    episodes_to_download = []
+    for entry, link in episodes_to_consider:
+        guid = entry.get('id', link.href)
+        cursor.execute("SELECT guid FROM episodes WHERE feed_id = ? AND guid = ?", (feed_id, guid))
+        if not cursor.fetchone():
+            episodes_to_download.append((entry, link))
+
+    total_to_download = len(episodes_to_download)
+    logging.info(f"Found {len(all_episodes)} total episodes. Considering {len(episodes_to_consider)}. Found {total_to_download} new episodes to download.")
+
     successful_downloads = 0
-    for entry in feed.entries:
-        if 'links' in entry:
-            for link in entry.links:
-                if link.type == 'audio/mpeg':
-                    audio_file_counter += 1
-                    date_str = entry.get('published', None)
-                    title = sanitize_title(entry.title, date_str)
+    for i, (entry, link) in enumerate(episodes_to_download):
+        date_str = entry.get('published', None)
+        title = sanitize_title(entry.title, date_str)
 
-                    # Parse URL for file extension / remove Query String, etc.
-                    parsed_url = urlparse(unquote(link.href))
-                    _, file_extension = os.path.splitext(parsed_url.path)
-                    filename = os.path.join(save_dir, title + file_extension)
+        # Parse URL for file extension
+        parsed_url = urlparse(unquote(link.href))
+        _, file_extension = os.path.splitext(parsed_url.path)
+        if not file_extension and link.type == 'audio/mpeg':
+            file_extension = '.mp3'
+            
+        filename = os.path.join(save_dir, title + file_extension)
 
-                    # Attempt to download the file
-                    if download_file(link.href, filename):
-                        successful_downloads += 1
-                        if save_text:
-                            logging.info(f"Saving additional details in text file {filename}")
-                            save_text_file(entry, filename)
-                    logging.info(f"Downloading audio file {audio_file_counter} of {total_audio_files}")
-                    logging.info("Sleeping for 1 second...")
-                    time.sleep(1)
-    logging.info("Completed! Successfully downloaded {} / {} audio files".format(successful_downloads, total_audio_files))
+        logging.info(f"Downloading audio file {i + 1} of {total_to_download}: {title}")
+        # Attempt to download the file
+        if download_file(link.href, filename):
+            guid = entry.get('id', link.href)
+            published_iso = ''
+            if entry.get('published_parsed'):
+                published_iso = datetime(*entry.published_parsed[:6]).strftime('%Y-%m-%dT%H:%M:%S')
+
+            try:
+                cursor.execute(
+                    "INSERT INTO episodes (feed_id, guid, title, published, filepath, downloaded_at) VALUES (?, ?, ?, ?, ?, ?)",
+                    (feed_id, guid, entry.title, published_iso, filename, datetime.now().isoformat())
+                )
+                conn.commit()
+                successful_downloads += 1
+            except sqlite3.IntegrityError:
+                logging.warning(f"Episode with GUID {guid} already in database for this feed. Skipping DB entry.")
+                continue
+
+            # Set MP3 tags
+            if filename.lower().endswith('.mp3'):
+                set_mp3_tags(filename, entry, feed)
+
+            if save_text:
+                save_text_file(entry, filename)
+        
+        if i < total_to_download - 1:
+            logging.info("Sleeping for 1 second...")
+            time.sleep(1)
+
+    logging.info("Completed! Successfully downloaded {} / {} audio files".format(successful_downloads, total_to_download))
 
 def main():
     parser = argparse.ArgumentParser(description='RSS Podcast Downloader')
     parser.add_argument('rss_url', help='RSS feed URL (Include authentication token if applicable)')
     parser.add_argument('save_dir', help='Directory to save downloaded files')
     parser.add_argument('--save_text', action='store_true', help='Flag to save text files with extra episode data')
+    parser.add_argument('--num-episodes', type=int, default=None, help='Number of additional episodes to download')
     args = parser.parse_args()
 
-    content = fetch_rss_feed(args.rss_url)
-    if content:
-        parse_and_download(content, args.save_dir, args.save_text)
+    # Create save_dir if it doesn't exist
+    if not os.path.exists(args.save_dir):
+        os.makedirs(args.save_dir)
+
+    conn = None
+    try:
+        content = fetch_rss_feed(args.rss_url)
+        if content:
+            feed = feedparser.parse(content)
+            conn = setup_database()
+            feed_id = get_or_create_feed(conn, args.rss_url, feed.feed.get('title', 'N/A'))
+            parse_and_download(content, args.save_dir, args.save_text, args.num_episodes, conn, feed_id, feed)
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}", exc_info=True)
+    finally:
+        if conn:
+            conn.close()
+            logging.info("Database connection closed.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Stateful Download Tracking via SQLite Database

Introduces a downloads.db SQLite database to persist a history of all downloaded episodes.
This prevents the re-downloading of episodes on subsequent runs, saving bandwidth and time.
The script now checks the database for the last downloaded episode's publication date and only fetches newer items from the RSS feed.
Multi-Feed Support

A feed_id (a hash of the RSS feed URL) has been added to the database schema.
This allows the script to track downloaded episodes from multiple, different podcast feeds independently within the same database.
Controlled Episode Downloading (--num-episodes)

The --num-episodes argument has been implemented to limit the number of new episodes to download in a single session.
This allows users to incrementally catch up on a large backlog of episodes instead of downloading them all at once.
The logic was fixed to correctly identify episodes published after the latest recorded download for the specific feed being processed.
Robust File Naming Sanitization

The function for generating filenames has been improved to strip out non-ASCII and special characters that are incompatible with FAT filesystems.
This ensures maximum compatibility across different operating systems and storage devices.
Improved Date Handling

A try-except block has been added around the date parsing logic. If an episode's publication date is in an unexpected format, the script will log an error and continue, preventing a crash.
Updated Documentation

The README.md file has been updated to document the new database functionality, the --num-episodes argument, and provide clearer usage examples.